### PR TITLE
feat: add skip option to prevent operation being executed

### DIFF
--- a/packages/client/src/exchanges/networkExchange.ts
+++ b/packages/client/src/exchanges/networkExchange.ts
@@ -16,23 +16,27 @@ const makeNetworkSource = (
   return Wonka.make<QoreOperationResult<AxiosRequestConfig>>(
     ({ next, complete }) => {
       const cancelToken = Axios.CancelToken.source();
-      const request = client.project.axios.request<
-        QoreOperationResultData<QoreOperationResult<AxiosRequestConfig>>
-      >({
-        ...operation.request,
-        cancelToken: cancelToken.token,
-        url: operation.request.url
-      });
-      request
-        .then(resp => {
-          next({ data: resp.data, operation, stale: false });
-        })
-        .catch(error => {
-          next({ error: error, operation, stale: false });
-        })
-        .finally(() => {
-          complete();
+      if (operation.skip) {
+        complete();
+      } else {
+        const request = client.project.axios.request<
+          QoreOperationResultData<QoreOperationResult<AxiosRequestConfig>>
+        >({
+          ...operation.request,
+          cancelToken: cancelToken.token,
+          url: operation.request.url
         });
+        request
+          .then(resp => {
+            next({ data: resp.data, operation, stale: false });
+          })
+          .catch(error => {
+            next({ error: error, operation, stale: false });
+          })
+          .finally(() => {
+            complete();
+          });
+      }
       return () => {
         cancelToken.cancel();
       };

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -33,6 +33,7 @@ export declare type QoreOperationConfig<T extends OptimisticResponse = {}> = {
   optimisticResponse?: T;
   optimisticStrategy?: "cache-first" | "optimistic-first";
   mode?: "sync" | "default" | "subscription";
+  skip?: boolean;
 };
 
 export type QoreOperation<


### PR DESCRIPTION
skip option is useful when operation depends on parameters that are not yet available. it also can be used to trigger query programmatically (lazy mode) with react.