### PR TITLE
fix: import schema with action javascript field

### DIFF
--- a/packages/cli/src/commands/import-schema.ts
+++ b/packages/cli/src/commands/import-schema.ts
@@ -64,6 +64,7 @@ export default class ImportSchema extends Command {
       if (err) return this.error(err);
       this.log(`\n${chalk.yellow(`\nRunning import-schema`)} ...\n`);
       files.sort((a: string, b: string) => +a.split("-")[0] - +b.split("-")[0]);
+      const migrations = await this.getMigrationsDataInDB(client);
       const migrationMap = this.mapMigrations(migrations);
       for (const file of files) {
         const jsonFile = await import(`${location}/${file}`);


### PR DESCRIPTION
> After trial and error, I found out that the error occurs when importing schema that includes action javascript is mainly because of the single quote `(')` in `migration.schema`, not the `migration.up` query. So I dont think encode the schema, up, and down migration to base64 when exporting schema would fix the problem as we need to decode it to string again when importing schema.
> 
> What I could proposed and works well (on my local) is to replace every single quote `(')` in schema (that already parsed into string) into a double single quote`('')` like what I've done for query up and down below
> 
> https://github.com/feedloop/qore-sdk/blob/89787efc362f911da25ae564bdeea0cd89414f72/packages/cli/src/commands/import-schema.ts#L83
> 
> the reason why I replace every single quote to a double single quote referred [here](https://www.postgresql.org/docs/current/app-psql.html)
> 
> <img alt="Screen Shot 2022-06-15 at 15 16 08" width="1315" src="https://user-images.githubusercontent.com/76815481/173777894-72ea90d3-1313-40d7-b81d-aae7c243f8ea.png">



[explanation](https://github.com/feedloop/qore-sdk/issues/56#issuecomment-1156146304)